### PR TITLE
fix: Cli receiving parameters with two dots

### DIFF
--- a/packages/scafflater-cli/commands/init.js
+++ b/packages/scafflater-cli/commands/init.js
@@ -56,7 +56,8 @@ export default class InitCommand extends Command {
     }),
     parameters: Flags.string({
       char: "p",
-      description: "The parameters to init template",
+      description:
+        "The parameters to init template. If the parameter is a dot separated name, it will be parsed as an object.",
       default: [],
       multiple: true,
     }),

--- a/packages/scafflater-cli/commands/partial/run.js
+++ b/packages/scafflater-cli/commands/partial/run.js
@@ -114,7 +114,8 @@ export default class RunPartialCommand extends Command {
     }),
     parameters: Flags.string({
       char: "p",
-      description: "The parameters to init template",
+      description:
+        "The parameters to run partial. If the parameter is a dot separated name, it will be parsed as an object.",
       default: [],
       multiple: true,
     }),

--- a/packages/scafflater-cli/util/index.js
+++ b/packages/scafflater-cli/util/index.js
@@ -11,13 +11,20 @@ export function parseParametersFlags(parameters) {
   const result = {};
 
   parameters.forEach((param) => {
-    const m = /(?<name>.+)(?::)(?<value>.+)/g.exec(param);
+    const m = /(?<name>[^:]+)(?::)(?<value>.+)/g.exec(param);
     if (m.length <= 0)
       throw new Error(
         "The parameters is not in the expected pattern: <parameter-name>:<parameter-value>",
       );
 
-    result[m.groups.name] = m.groups.value;
+    // build an object if the parameter name is a dot separated name
+    const nameSplit = m.groups.name.split(".");
+    let current = result;
+    for (let i = 0; i < nameSplit.length - 1; i++) {
+      if (!current[nameSplit[i]]) current[nameSplit[i]] = {};
+      current = current[nameSplit[i]];
+    }
+    current[nameSplit[nameSplit.length - 1]] = m.groups.value;
   });
 
   return result;

--- a/packages/scafflater-cli/util/index.test.js
+++ b/packages/scafflater-cli/util/index.test.js
@@ -24,14 +24,24 @@ const { prompt } = (await import("inquirer")).default;
 
 test("Parse Parameters Flags", () => {
   // ARRANGE
-  const parameters = ["name1:value1", "name2:value2"];
+  const parameters = [
+    "name1:value1",
+    "name2:value2",
+    "github.repoUrl:https://github.com/grupoboticario/alquimia-template-flutter-lib",
+    "github.repo.other.url:https://other.url.com",
+  ];
 
   // ACT
   const result = parseParametersFlags(parameters);
 
   // ASSERT
+  console.log(result);
   expect(result.name1).toBe("value1");
   expect(result.name2).toBe("value2");
+  expect(result.github.repoUrl).toBe(
+    "https://github.com/grupoboticario/alquimia-template-flutter-lib",
+  );
+  expect(result.github.repo.other.url).toBe("https://other.url.com");
 });
 
 describe("promptMissingParameters", () => {


### PR DESCRIPTION
The parser failed if cli receives an value with two dots ( : ). The fix includes the possibility to receive values with two dots and if the parameter is a dot separated name, it will be parsed as an object.